### PR TITLE
Don't set HTTP_IF_NONE_MATCH to nil if etags missing

### DIFF
--- a/lib/rack/cache/context.rb
+++ b/lib/rack/cache/context.rb
@@ -214,7 +214,7 @@ module Rack::Cache
       cached_etags = entry.etag.to_s.split(/\s*,\s*/)
       request_etags = @request.env['HTTP_IF_NONE_MATCH'].to_s.split(/\s*,\s*/)
       etags = (cached_etags + request_etags).uniq
-      @env['HTTP_IF_NONE_MATCH'] = etags.empty? ? nil : etags.join(', ')
+      @env['HTTP_IF_NONE_MATCH'] = etags.join(', ') unless etags.empty?
       response = forward
 
       if response.status == 304


### PR DESCRIPTION
Similar to the problem I fixed in a previous PR with HTTP_IF_MODIFIED_SINCE being set to nil.  I assume this is something that changed in a newer version of Rails, that it no longer accepts nil for these header values.

rake test
.................................................................................................................................................................................................................................................................................................................................................................
Finished in 1.295495 seconds.

353 tests, 1095 assertions, 0 failures, 0 errors
