### PR TITLE
Removed missed constant

### DIFF
--- a/lib/rack/cache/context.rb
+++ b/lib/rack/cache/context.rb
@@ -24,10 +24,6 @@ module Rack::Cache
     # The Rack application object immediately downstream.
     attr_reader :backend
 
-    # Set of exceptions that indicate a network connection failure.
-    # TODO: Make these configurable, to work in a non-faraday environment.
-    EXCEPTION_CLASSES = Set.new %w(Timeout::Error Faraday::Error::ConnectionFailed Faraday::Error::TimeoutError)
-
     def initialize(backend, options={})
       @backend = backend
       @trace = []


### PR DESCRIPTION
@clabrunda Please merge.

Missed removing this constant that was refactored to method.

All tests passing:

Finished in 0.511981 seconds.

268 tests, 975 assertions, 0 failures, 0 errors
