### PR TITLE
Feature/allow private caching

### DIFF
--- a/lib/rack/cache/context.rb
+++ b/lib/rack/cache/context.rb
@@ -270,7 +270,7 @@ module Rack::Cache
         record :invalid
       end
 
-      store(response) if response.cacheable?
+      store(response) if response.cacheable?(private_cache?)
 
       response
     end
@@ -297,7 +297,7 @@ module Rack::Cache
         response.ttl = default_ttl
       end
 
-      store(response) if response.cacheable?
+      store(response) if response.cacheable?(private_cache?)
 
       response
     end

--- a/lib/rack/cache/options.rb
+++ b/lib/rack/cache/options.rb
@@ -112,6 +112,11 @@ module Rack::Cache
     # failure or times out.
     option_accessor :fault_tolerant
 
+    # Specifies whether to cache responses that are designated private
+    # Disabled by default, only turn this on if you will not be passing
+    # the response on or can handle access control for all responses.
+    option_accessor :private_cache
+
     # The underlying options Hash. During initialization (or outside of a
     # request), this is a default values Hash. During a request, this is the
     # Rack environment Hash. The default values Hash is merged in underneath
@@ -155,6 +160,7 @@ module Rack::Cache
         'rack-cache.allow_revalidate' => false,
         'rack-cache.use_native_ttl'   => false,
         'rack-cache.fault_tolerant'   => false,
+        'rack-cache.private_cache'    => false,
       }
       self.options = options
     end

--- a/lib/rack/cache/response.rb
+++ b/lib/rack/cache/response.rb
@@ -93,15 +93,16 @@ module Rack::Cache
       ttl && ttl > 0
     end
 
-    # Determine if the response is worth caching under any circumstance. Responses
-    # marked "private" with an explicit Cache-Control directive are considered
-    # uncacheable
+    # Determine if the response is worth caching under any circumstance.
+    # Responses marked "private" with an explicit Cache-Control directive
+    # or any configured private header are uncacheable unless private_cache is enabled
     #
     # Responses with neither a freshness lifetime (Expires, max-age) nor cache
     # validator (Last-Modified, ETag) are considered uncacheable.
-    def cacheable?
+    def cacheable?(private_cache = false)
       return false unless CACHEABLE_RESPONSE_CODES.include?(status)
-      return false if cache_control.no_store? || cache_control.private?
+      return false if cache_control.no_store?
+      return false if !private_cache && cache_control.private?
       validateable? || fresh?
     end
 

--- a/test/context_test.rb
+++ b/test/context_test.rb
@@ -65,7 +65,6 @@ describe 'Rack::Cache::Context' do
   it 'does not cache with Cookie header and non public response' do
     respond_with 200, 'ETag' => '"FOO"'
     get '/', 'HTTP_COOKIE' => 'foo=bar'
-
     app.should.be.called
     response.should.be.ok
     response.headers['Cache-Control'].should.equal 'private'
@@ -258,6 +257,14 @@ describe 'Rack::Cache::Context' do
     response.should.be.ok
     cache.trace.should.include :store
     response.headers.should.include 'Age'
+  end
+
+  it 'stores private responses when private_cache is set to true' do
+    respond_with 200, 'Cache-Control' => 'max-age=10000, private'
+
+    get '/', 'rack-cache.private_cache' => true
+    response.should.be.ok
+    cache.trace.should.include :store
   end
 
   it 'reloads responses when cache hits but no-cache request directive present ' +


### PR DESCRIPTION
The Cache-Control setting "private" should not prevent caching in all circumstances. This PR adds the configuration option `private_cache` to allow caching when the caller is the endpoint or is handling access control.

`rake test` passes. I don't have dalli up locally but I doubt that's relevant.
