### PR TITLE
Deprecate

### DIFF
--- a/README
+++ b/README
@@ -1,3 +1,8 @@
+* DEPRECATED *
+
+This forked Rack::Cache is deprecated. Please use the upstream.
+
+
 Rack::Cache
 ===========
 


### PR DESCRIPTION
Since this forked version is not following the changes in the upstream, it is blocking to update other gems. 
Also, the added features are already migrated or not valid anymore. 

## Details

The following features are added to this forked rack-cache:

- fault_tolerant
- retries
- private_cache
- cache report API

### fault_tolerant #2
Added the equivalent feature to the upstream gem: https://github.com/rtomayko/rack-cache/pull/168
However, the per-request feature, `:fallback_to_cache`, is not added.

In FaradayMiddleware::RackCompatible, [this change](https://github.com/lostisland/faraday_middleware/pull/88/files#diff-8861afcaa140f714e4782f1bf8526cfaR39) was made in 2014.

Since then, we cannot directly access to the Faraday custom options in the rack env like this:
https://github.com/mdsol/rack-cache/blob/f7476a21e8c2b9be294eedb6d4681b8cfdaa90f2/lib/rack/cache/context.rb#L230

I believe this feature has been unable to use for quite some time.

### retries #4
This is also a per-request feature:
https://github.com/mdsol/rack-cache/blob/f7476a21e8c2b9be294eedb6d4681b8cfdaa90f2/lib/rack/cache/context.rb#L348

Same as the `:fallback_to_cache` feature, it's invalid now. 

### private_cache #12
We have the equivalent feature in the Eureka::Client::CacheMiddleware, removing `private` from the "Cache-Control" header.


### cache report API #16
Eureka-client is not setting the `X-HTTP-Method-Override` header anymore.


@HonoreDB @ejennings-mdsol @cmcinnes-mdsol @ejinotti-mdsol @jcarres-mdsol @jfeltesse-mdsol 